### PR TITLE
fix: 구독 백엔드 응답 방법 수정에 따른 프론트 수정 및 feat-13 머지 오류 수정

### DIFF
--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -205,7 +205,7 @@ export function AdminPage({
   onModelCreation,
   onMarketplace,
   onMyPage,
-  onPointsSubscription
+  onPointsSubscription,
   onAdmin
 }: AdminPageProps) {
   const [searchQuery, setSearchQuery] = useState('');

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from './ui/button';
-import { Sparkles, Menu, X, Camera, ShoppingBag, User, Palette, LogOut, ArrowLeft, Shield } from 'lucide-react';
+import { Sparkles, Menu, X, Camera, ShoppingBag, User, Palette, LogOut, ArrowLeft, Shield, Coins } from 'lucide-react';
 
 interface NavigationBarProps {
   onLogin: () => void;

--- a/src/components/PointsSubscriptionPage.tsx
+++ b/src/components/PointsSubscriptionPage.tsx
@@ -68,7 +68,7 @@ export default function PointsSubscriptionPage({
             credentials: "include",
         })
             .then((res) => res.json())
-            .then((data) => setCurrentSubscription(data.response || null))
+            .then((data) => setCurrentSubscription(data || null))
             .catch(() => setCurrentSubscription(null));
 
         // 구독 플랜 목록 조회
@@ -77,7 +77,7 @@ export default function PointsSubscriptionPage({
             credentials: "include",
         })
             .then((res) => res.json())
-            .then((data) => setPlans(data.response || []))
+            .then((data) => setPlans(data || []))
             .catch(() => setPlans([]));
     };
 
@@ -126,12 +126,13 @@ export default function PointsSubscriptionPage({
                 }),
             });
 
-            const result = await response.json();
-            if (result.success) {
+            if (response.ok) {
+                const result = await response.json();
                 alert("✅ FREE 플랜 등록 완료!");
                 loadSubscriptions(); // 새로고침 대신 현황 갱신
             } else {
-                alert("❌ FREE 플랜 등록 실패: " + result.error?.message);
+                const errorData = await response.json().catch(() => ({}));
+                alert("❌ FREE 플랜 등록 실패: " + (errorData.message || response.statusText));
             }
             return;
         }
@@ -164,12 +165,13 @@ export default function PointsSubscriptionPage({
                         }),
                     });
 
-                    const result = await response.json();
-                    if (result.success) {
+                    if (response.ok) {
+                        const result = await response.json();
                         alert(`✅ ${selectedPlan.planType} 구독 결제 성공 및 등록 완료!`);
                         loadSubscriptions(); // 🔥 새로고침 대신 현황 갱신
                     } else {
-                        alert("❌ 백엔드 등록 실패: " + result.error?.message);
+                        const errorData = await response.json().catch(() => ({}));
+                        alert("❌ 백엔드 등록 실패: " + (errorData.message || response.statusText));
                     }
                 } else {
                     alert("❌ 결제 실패: " + rsp.error_msg);
@@ -188,12 +190,13 @@ export default function PointsSubscriptionPage({
             }
         );
 
-        const result = await response.json();
-        if (result.success) {
+        if (response.ok) {
+            const result = await response.json();
             alert("✅ 구독이 취소되었습니다.");
             loadSubscriptions(); // 🔥 새로고침 대신 현황 갱신
         } else {
-            alert("❌ 구독 취소 실패: " + result.error?.message);
+            const errorData = await response.json().catch(() => ({}));
+            alert("❌ 구독 취소 실패: " + (errorData.message || response.statusText));
         }
     };
 
@@ -234,7 +237,7 @@ export default function PointsSubscriptionPage({
                             {currentSubscription ? (
                                 <>
                                     <p className="text-xl font-bold text-green-600">
-                                        {planTypeMap[currentSubscription.subscriptionId] || "알 수 없음"}
+                                        {planTypeMap[currentSubscription.subscriptionId] || "미구독"}
                                     </p>
                                     <p className="text-xs text-gray-500 mt-1">
                                         만료일:{" "}
@@ -309,7 +312,7 @@ export default function PointsSubscriptionPage({
                                 <h2 className="font-bold text-lg">{plan.planType}</h2>
                                 <p className="text-sm text-gray-500">{plan.description}</p>
                                 <p className="mt-2 font-semibold">
-                                    {plan.price}원 / {plan.period}일
+                                    {plan.price}$ / {plan.period}일
                                 </p>
                             </div>
                         ))}


### PR DESCRIPTION
## ⭐Key Changes
1. 백엔드 응답 방법 변경에 따른 프론트 변경(ApiUtils -> ResponseEntity)
<feat-13머지 오류 수정>
2. AdminPage.tsx의 208번째 줄에 콤마 추가
3. NavigationBar.tsx에 import Coins 추가

<br>

## 📌Issue
> "close #18
<br>

## 👪To Reviewers
> 

<br>

## 🐾Next Move
> 포인트 프론트 연결 및 결제 연동
