### PR TITLE
refactor: 회원가입 요청 필드를 name에서 username으로 변경

### DIFF
--- a/src/components/SignupPage.tsx
+++ b/src/components/SignupPage.tsx
@@ -20,7 +20,7 @@ interface SignupPageProps {
 
 export function SignupPage({ onSignupSuccess, onLogin, onBack }: SignupPageProps) {
   const [formData, setFormData] = useState({
-    name: '',
+    username: '',
     email: '',
     password: '',
     confirmPassword: ''
@@ -69,7 +69,7 @@ export function SignupPage({ onSignupSuccess, onLogin, onBack }: SignupPageProps
     
     try {
       const signupData: SignupRequest = {
-        name: formData.name,
+        username: formData.username,
         email: formData.email,
         password: formData.password,
         agreeToTerms: agreements.terms,
@@ -102,7 +102,7 @@ export function SignupPage({ onSignupSuccess, onLogin, onBack }: SignupPageProps
     window.location.href = `${API_BASE}/oauth2/authorization/${provider}`;
   };
 
-  const isFormValid = formData.name && formData.email && formData.password && 
+  const isFormValid = formData.username && formData.email && formData.password &&
                       formData.confirmPassword && agreements.terms && agreements.privacy;
 
   return (
@@ -218,17 +218,19 @@ export function SignupPage({ onSignupSuccess, onLogin, onBack }: SignupPageProps
             {/* Email Signup Form */}
             <form onSubmit={handleSubmit} className="space-y-6">
               <div className="space-y-2">
-                <Label htmlFor="name" className="text-sm font-medium text-foreground">
-                  이름
+                <Label htmlFor="username" className="text-sm font-medium text-foreground">
+                  사용자명
                 </Label>
                 <div className="relative">
                   <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                   <Input
-                    id="name"
+                    id="username"
                     type="text"
-                    placeholder="홍길동"
-                    value={formData.name}
-                    onChange={(e) => handleInputChange('name', e.target.value)}
+                    placeholder="username"
+                    value={formData.username}
+                    onChange={(e) => handleInputChange('username', e.target.value)}
+                    minLength={2}
+                    maxLength={20}
                     required
                     className="pl-10 h-12 text-base bg-background border-2 focus:border-primary/50 transition-colors"
                   />

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,7 +17,7 @@ export interface LoginResponse {
 }
 
 export interface SignupRequest {
-  name: string;
+  username: string;
   email: string;
   password: string;
   agreeToTerms: boolean;


### PR DESCRIPTION
## Summary
• 백엔드 API 스펙에 맞춰 회원가입 요청 필드를 수정
• SignupRequest 타입의 name 필드를 username으로 변경
• 회원가입 폼 UI 라벨 및 필드명 업데이트
• 백엔드 validation 규칙에 맞춰 minLength(2), maxLength(20) 추가

## Test plan
- [ ] 회원가입 폼에서 사용자명 필드 정상 동작 확인
- [ ] 백엔드 API와 정상 연동 확인
- [ ] 사용자명 입력 검증 (2-20자) 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)