### PR TITLE
refactor: 마이페이지 -> 포인트&구독

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1079,6 +1079,7 @@ export default function App() {
           onMyPage={() => handleStageChange('mypage')}
           onHome={() => handleStageChange('landing')}
           onAdmin={() => handleStageChange('admin')}
+          onPointsSubscription={() => handleStageChange('pointsSubscription')}
         />
       )}
 

--- a/src/components/MyModels.tsx
+++ b/src/components/MyModels.tsx
@@ -1026,7 +1026,7 @@ export function MyModels({
       <ModelDetailDialog
         modelId={selectedModelIdForDetail}
         open={detailDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!open) {
             setDetailDialogOpen(false);
             setSelectedModelIdForDetail(null);
@@ -1038,7 +1038,7 @@ export function MyModels({
 
       <Dialog
         open={priceDialogOpen}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!open) {
             closePriceDialog();
           }

--- a/src/components/MyPage.tsx
+++ b/src/components/MyPage.tsx
@@ -446,12 +446,13 @@ export function MyPage({ userProfile, projects = defaultMockProjects, onProjectS
             </Card>
 
             <Card 
-              className="p-4"
+              className="p-4 cursor-pointer transition-transform hover:translate-y-[-2px]"
               style={{
                 backgroundColor: 'var(--color-background-primary)',
                 borderColor: 'var(--color-border-primary)',
                 borderRadius: 'var(--radius-12)'
               }}
+              onClick={() => onPointsSubscription?.()}
             >
               <div className="flex items-center gap-4">
                 <div 
@@ -471,7 +472,7 @@ export function MyPage({ userProfile, projects = defaultMockProjects, onProjectS
                     보유 포인트
                   </p>
                   <DynamicFontSize
-                    text={`${userProfile.points.toLocaleString()} P`}
+                    text={`${(userProfile.points ?? 0).toLocaleString()} P`}
                     baseSize="var(--font-size-title3)"
                     maxWidth="140px"
                     minSize="12px"

--- a/src/components/ProductImageUpload.tsx
+++ b/src/components/ProductImageUpload.tsx
@@ -28,6 +28,7 @@ interface ProductImageUploadProps {
   onMyPage: () => void;
   onHome: () => void;
   onAdmin?: () => void;
+  onPointsSubscription?: () => void;
 }
 
 export function ProductImageUpload({ 
@@ -42,7 +43,8 @@ export function ProductImageUpload({
   onMarketplace, 
   onMyPage, 
   onHome, 
-  onAdmin 
+  onAdmin,
+  onPointsSubscription
 }: ProductImageUploadProps) {
   const [uploadedImage, setUploadedImage] = useState<string | null>(null);
   const [additionalPrompt, setAdditionalPrompt] = useState('');
@@ -364,6 +366,7 @@ export function ProductImageUpload({
         onHome={onHome}
         onBack={onBack}
         onAdmin={onAdmin}
+        onPointsSubscription={onPointsSubscription}
         isAdmin={userProfile?.role === 'ADMIN'}
         isLoggedIn={!!userProfile}
         showBackButton={true}


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 변경 사항 1
2. 변경 사항 2
3. ...

<br>

## 📌Issue
> "close #이슈번호"로 해당 이슈 완료해주세요.

<br>

## 👪To Reviewers
> reviewer 에게 하고 싶은 말을 적어주세요.

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 랜딩 페이지와 상품 이미지 업로드 화면에서 포인트 구독 흐름으로 바로 이동할 수 있습니다.
  - 마이페이지의 ‘보유 포인트’ 카드 클릭 시 포인트 구독으로 이동합니다.
- UI
  - ‘보유 포인트’ 카드에 호버 애니메이션과 포인터 커서를 추가했습니다.
  - 포인트 표시를 개선해 값이 없을 때 0으로 표기하고 천 단위 구분을 적용했습니다.
- 리팩터
  - 일부 열림 상태 변경 핸들러의 시그니처를 명확화했습니다(동작 변경 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->